### PR TITLE
Fixed noisy error messages when a perlcritic policy is not installed

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -58,15 +58,31 @@ module.exports = {
         const cwd = self.getCwd(filePath);
 
         // Execute the perlcritic command
-        const result = await Helpers.exec(
+        let result;
+        await Helpers.exec(
           command,
           parameters, {
             stdin: textEditor.getText(),
             cwd,
             env: process.env,
             ignoreExitCode: true,
-          },
-        );
+          }
+        ).then((response) => {
+          result = response;
+        }).catch((error) => {
+          let notifications = atom.notifications.getNotifications();
+          let isDisplayingNotification = false;
+          notifications.forEach((notification) => {
+            if (notification.dismissed == false) {
+              isDisplayingNotification = true;
+            }
+          });
+          if (!isDisplayingNotification) {
+            atom.notifications.addError(`Error: ${error.message}`, {
+              dismissable: true 
+            });
+          }
+        });
 
         // Parse result
         let regex = new RegExp(atom.config.get('linter-perlcritic.regex'), 'ig');


### PR DESCRIPTION
Key changes:

- Remove the stack trace from the notification message so the message is much more compact
- Ensure that multiple notifications are not spawned for the same message each time the linter attempts to access the missing policy
- If there is a notification message currently visible (one that has not been dismissed yet) then the linter will no longer continue to generate notification messages each time the missing policy fails

See screenshots for additional details.
Cheers

Before change:

<img width="976" alt="before" src="https://cloud.githubusercontent.com/assets/1466457/20857984/24b28bea-b98e-11e6-83cc-7b3c19bd3db6.png">

After change:

![after](https://cloud.githubusercontent.com/assets/1466457/20857988/306450ea-b98e-11e6-8c0d-9e949ab75ee7.png)

