### PR TITLE
Prevent false positive errors when document changes during linting

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -56,13 +56,16 @@ module.exports = {
         // get cwd
         const filePath = textEditor.getPath();
         const cwd = self.getCwd(filePath);
-
+        
+        // get document text
+        const fileText = textEditor.getText();
+        
         // Execute the perlcritic command
         let result;
         await Helpers.exec(
           command,
           parameters, {
-            stdin: textEditor.getText(),
+            stdin: fileText,
             cwd,
             env: process.env,
             ignoreExitCode: true,
@@ -84,6 +87,11 @@ module.exports = {
           }
         });
 
+        // Return if document has changed
+        if (textEditor.getText() !== fileText) {
+          return null;
+        }
+        
         // Parse result
         let regex = new RegExp(atom.config.get('linter-perlcritic.regex'), 'ig');
         regex = NamedRegexp.named(regex);


### PR DESCRIPTION
This change protects against an error which can occur when the user edits the document after it was sent to the linter but before the results are returned. This change addresses the bug identified in https://github.com/AtomLinter/atom-linter-perlcritic/issues/35