### PR TITLE
Add options for the output

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -57,16 +57,6 @@ const parseCmdOptions = (cmdOptions) => {
     });
   }
 
-  // Force the output format to our predefined one
-  // See the following for more details:
-  // http://search.cpan.org/~petdance/Perl-Critic-1.130/lib/Perl/Critic/Violation.pm#OVERLOADS
-  // The double separator at the end is needed to distinguish between multiple
-  // records since the %d output spans multiple lines.
-  parameters.push('-verbose');
-  parameters.push(`%L:%c${sep}%m${sep}%e${sep}%p${sep}%s${sep}%d${sep}${sep}\\n`);
-
-  parameters.push('-');
-
   return parameters;
 };
 
@@ -101,6 +91,18 @@ export default {
       atom.config.observe('linter-perlcritic.level', (value) => {
         this.level = value;
       }),
+      atom.config.observe('linter-perlcritic.showSeverity', (value) => {
+        this.showSeverity = value;
+      }),
+      atom.config.observe('linter-perlcritic.showExplanation', (value) => {
+        this.showExplanation = value;
+      }),
+      atom.config.observe('linter-perlcritic.showPolicy', (value) => {
+        this.showPolicy = value;
+      }),
+      atom.config.observe('linter-perlcritic.forceMinimumSeverity', (value) => {
+        this.forceMinimumSeverity = value;
+      }),
     );
   },
 
@@ -125,6 +127,19 @@ export default {
         // Parse command options, replace space by '='
         const cmdOptions = this.commandlineOptions;
         const parameters = parseCmdOptions(cmdOptions);
+        // Force the output format to our predefined one
+        // See the following for more details:
+        // http://search.cpan.org/~petdance/Perl-Critic-1.130/lib/Perl/Critic/Violation.pm#OVERLOADS
+        // The double separator at the end is needed to distinguish between multiple
+        // records since the %d output spans multiple lines.
+        parameters.push('-verbose');
+        parameters.push(`%L:%c${sep}%m${sep}%e${sep}%p${sep}%s${sep}%d${sep}${sep}\\n`);
+
+        if (this.forceMinimumSeverity !== 'none') {
+          parameters.push(`--${this.forceMinimumSeverity}`);
+        }
+
+        parameters.push('-');
 
         // get cwd
         const filePath = textEditor.getPath();
@@ -181,10 +196,20 @@ export default {
         while (match !== null) {
           const line = Math.max(Number.parseInt(match[1], 10) - 1, 0);
           const col = Math.max(Number.parseInt(match[2], 10) - 1, 0);
+          const excerptParts = [match[3]];
+          if (this.showSeverity) {
+            excerptParts.push(`(Severity ${match[6]})`);
+          }
+          if (this.showExplanation) {
+            excerptParts.push(`[${match[4]}.]`);
+          }
+          if (this.showPolicy) {
+            excerptParts.push(`<${match[5]}>`);
+          }
 
           messages.push({
             severity: this.level,
-            excerpt: `${match[3]} (Severity ${match[6]}) [${match[4]}.]`,
+            excerpt: excerptParts.join(' '),
             location: {
               file: filePath,
               position: Helpers.generateRange(textEditor, line, col),

--- a/package.json
+++ b/package.json
@@ -40,6 +40,52 @@
       "type": "string",
       "title": "Additional Commandline options",
       "default": ""
+    },
+    "showSeverity": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show the severity number of the violation."
+    },
+    "showExplanation": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show the short explanation or PBP page reference of the violation."
+    },
+    "showPolicy": {
+      "type": "boolean",
+      "default": false,
+      "description": "Show the policy that reported the violation."
+    },
+    "forceMinimumSeverity": {
+      "type": "string",
+      "default": "none",
+      "description": "Force `perlcritic` to apply policies of a certain severity.",
+      "enum": [
+        {
+          "value": "none",
+          "description": "No forced severity."
+        },
+        {
+          "value": "gentle",
+          "description": "Gentle (>5)"
+        },
+        {
+          "value": "stern",
+          "description": "Stern (>4)"
+        },
+        {
+          "value": "harsh",
+          "description": "Harsh (>3)"
+        },
+        {
+          "value": "cruel",
+          "description": "Cruel (>2)"
+        },
+        {
+          "value": "brutal",
+          "description": "Brutal (>=1)"
+        }
+      ]
     }
   },
   "license": "MIT",

--- a/spec/atom-linter-perlcritic-spec.js
+++ b/spec/atom-linter-perlcritic-spec.js
@@ -9,6 +9,15 @@ const { lint } = require('../lib/init.js').provideLinter();
 const goodPath = path.join(__dirname, 'fixtures', 'good.pl');
 const badPath = path.join(__dirname, 'fixtures', 'bad.pl');
 
+const cbsExcerpt = 'Code before strictures are enabled (Severity 5) [See page 429 of PBP.]';
+
+const checkCbsMessage = (message, excerpt = cbsExcerpt) => {
+  expect(message.severity).toBe('info');
+  expect(message.excerpt).toBe(excerpt);
+  expect(message.location.file).toBe(badPath);
+  expect(message.location.position).toEqual([[1, 0], [1, 2]]);
+};
+
 describe('The perlcritic provider for Linter', () => {
   beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
@@ -25,14 +34,104 @@ describe('The perlcritic provider for Linter', () => {
   });
 
   it('properly shows messages for a problematic file', async () => {
-    const cbS = 'Code before strictures are enabled (Severity 5) [See page 429 of PBP.]';
     const editor = await atom.workspace.open(badPath);
     const messages = await lint(editor);
 
-    expect(messages.length).toBeGreaterThan(0);
-    expect(messages[0].severity).toBe('info');
-    expect(messages[0].excerpt).toBe(cbS);
-    expect(messages[0].location.file).toBe(badPath);
-    expect(messages[0].location.position).toEqual([[1, 0], [1, 2]]);
+    expect(messages.length).toBe(1);
+    checkCbsMessage(messages[0]);
+  });
+
+  describe('has settings that control the output', () => {
+    it('allows controlling whether the severity shows', async () => {
+      atom.config.set('linter-perlcritic.showSeverity', true);
+      const editor = await atom.workspace.open(badPath);
+      const messages = await lint(editor);
+
+      expect(messages.length).toBe(1);
+      checkCbsMessage(messages[0]);
+
+      atom.config.set('linter-perlcritic.showSeverity', false);
+
+      const newMessages = await lint(editor);
+      expect(newMessages.length).toBe(1);
+      const excerpt = 'Code before strictures are enabled [See page 429 of PBP.]';
+      checkCbsMessage(newMessages[0], excerpt);
+    });
+
+    it('allows controlling whether the explanation shows', async () => {
+      atom.config.set('linter-perlcritic.showExplanation', true);
+      const editor = await atom.workspace.open(badPath);
+      const messages = await lint(editor);
+
+      expect(messages.length).toBe(1);
+      checkCbsMessage(messages[0]);
+
+      atom.config.set('linter-perlcritic.showExplanation', false);
+
+      const newMessages = await lint(editor);
+      expect(newMessages.length).toBe(1);
+      const excerpt = 'Code before strictures are enabled (Severity 5)';
+      checkCbsMessage(newMessages[0], excerpt);
+    });
+
+    it('allows controlling whether the policy shows', async () => {
+      atom.config.set('linter-perlcritic.showPolicy', false);
+      const editor = await atom.workspace.open(badPath);
+      const messages = await lint(editor);
+
+      expect(messages.length).toBe(1);
+      checkCbsMessage(messages[0]);
+
+      atom.config.set('linter-perlcritic.showPolicy', true);
+
+      const newMessages = await lint(editor);
+      expect(newMessages.length).toBe(1);
+      const excerpt = `${cbsExcerpt} <TestingAndDebugging::RequireUseStrict>`;
+      checkCbsMessage(newMessages[0], excerpt);
+    });
+  });
+
+  describe('allows controlling the forced severity shown', () => {
+    // This should actually test against a config file that uses a specific severity...
+    let editor;
+
+    beforeEach(async () => {
+      editor = await atom.workspace.open(badPath);
+    });
+
+    it('defaults to not forcing the policy', async () => {
+      atom.config.set('linter-perlcritic.forceMinimumSeverity', 'none');
+      const messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      checkCbsMessage(messages[0]);
+    });
+
+    it('supports forcing gentle severity', async () => {
+      atom.config.set('linter-perlcritic.forceMinimumSeverity', 'gentle');
+      const messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      checkCbsMessage(messages[0]);
+    });
+
+    it('supports forcing stern severity', async () => {
+      atom.config.set('linter-perlcritic.forceMinimumSeverity', 'stern');
+      const messages = await lint(editor);
+      expect(messages.length).toBe(4);
+      checkCbsMessage(messages[2]);
+    });
+
+    it('supports forcing harsh severity', async () => {
+      atom.config.set('linter-perlcritic.forceMinimumSeverity', 'harsh');
+      const messages = await lint(editor);
+      expect(messages.length).toBe(4);
+      checkCbsMessage(messages[2]);
+    });
+
+    it('supports forcing cruel severity', async () => {
+      atom.config.set('linter-perlcritic.forceMinimumSeverity', 'cruel');
+      const messages = await lint(editor);
+      expect(messages.length).toBe(6);
+      checkCbsMessage(messages[3]);
+    });
   });
 });


### PR DESCRIPTION
Add options controlling what shows in the output, by default this follows the current output format, but adds an option to show the policy name that provided the violation. Options are also added to remove the
display of the severity and the short explanation (PBP page).
