### PR TITLE
Make CircleCI caches more specific

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ defaults: &defaults
     - save_cache:
         paths:
           - node_modules
-        key: v2-dependencies-{{ checksum "package.json" }}
+        key: v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
 
 jobs:
   checkout_code:
@@ -69,10 +69,15 @@ jobs:
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v2-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v2-dependencies
+          # Get latest cache for this package.json and pacakge-lock.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v3-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v3-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,6 @@ defaults: &defaults
         name: APM version
         command: ${APM_SCRIPT_PATH} --version
     - run:
-        name: Cleaning package
-        command: ${APM_SCRIPT_PATH} clean
-    - run:
         name: Package APM package dependencies
         command: |
           if [ -n "${APM_TEST_PACKAGES}" ]; then
@@ -50,6 +47,9 @@ defaults: &defaults
     - run:
         name: Package dependencies
         command: ${APM_SCRIPT_PATH} install
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
     - run:
         name: Package specs
         command: ${ATOM_SCRIPT_PATH} --test spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,16 @@ defaults: &defaults
     # Restore project state
     - attach_workspace:
         at: /tmp
+    # Restore App::cpanminus cache
+    - restore_cache:
+        keys:
+        # Get latest cache for the current specs
+        - v1-cpanminus-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+        # Fall back to the latest for the current branch
+        - v1-cpanminus-{{ arch }}-{{ .Branch }}-
+        # Fall back to the latest for master
+        - v1-cpanminus-{{ arch }}-master-
+        # Don't fall back any further
     - run:
         name: Install Perl
         command: |
@@ -22,8 +32,18 @@ defaults: &defaults
         name: App::cpanminus version
         command: cpanm --version
     - run:
+        name: Configure local Perl lib path
+        command: |
+          cpanm --local-lib=~/perl5 local::lib && \
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib) && \
+          echo 'export PERL5LIB=/home/atom/perl5/lib/perl5' >> $BASH_ENV && \
+          echo 'export PERL_LOCAL_LIB_ROOT=/home/atom/perl5' >> $BASH_ENV && \
+          echo 'export PERL_MB_OPT="--install_base \"/home/atom/perl5\""' >> $BASH_ENV && \
+          echo 'export PERL_MM_OPT=INSTALL_BASE=/home/atom/perl5' >> $BASH_ENV && \
+          echo 'export PATH="/home/atom/perl5/bin:$PATH"' >> $BASH_ENV
+    - run:
         name: Install Perl::Critic
-        command: sudo cpanm install Perl::Critic
+        command: cpanm install Perl::Critic
     - run:
         name: Perl::Critic version
         command: perlcritic --version
@@ -58,6 +78,11 @@ defaults: &defaults
         paths:
           - node_modules
         key: v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+    # Cache Perl Modules
+    - save_cache:
+        paths:
+          - "~/perl5"
+        key: v1-cpanminus-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
 
 jobs:
   checkout_code:


### PR DESCRIPTION
Make the `node_modules` cache save under a hierarchy that follows this order:
1. current branch -> package.json -> package-lock.json
2. current branch -> package.json
3. current branch
4. `master` branch

Notably this will prevent a cache saved in a PR that updates a dependency from saving a cache that is then reused in other branches.

This also adds caching of the Perl modules, allowing the 5 minute builds to hopefully cut out ~4 minutes out of the build time if the installation of `Perl::Critic` is already cached and up to date.

The hierarchy for the Perl module cache is:
1. architecture -> current branch -> circleci/config.yml version
2. architecture -> current branch
3. architecture -> `master` branch

Also moves running `apm clean` to _after_ `apm install` to prevent a chicken and egg problem with `husky`.