### PR TITLE
feat: map linter severity to perlcritic severity

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -122,6 +122,25 @@ export default {
         // Ensure dependencies are loaded
         loadDeps();
 
+        const getLinterSeverity = (perlsev) => {
+          if (this.level !== 'auto') {
+            return this.level;
+          }
+
+          switch (perlsev) {
+            case '1':
+            case '2':
+              return 'error';
+            case '3':
+              return 'warning';
+            case '4':
+            case '5':
+              return 'info';
+            default:
+              return 'warning';
+          }
+        };
+
         const command = this.executablePath;
 
         // Parse command options, replace space by '='
@@ -194,6 +213,7 @@ export default {
         const messages = [];
         let match = regex.exec(result);
         while (match !== null) {
+          const lintsev = getLinterSeverity(match[6]);
           const line = Math.max(Number.parseInt(match[1], 10) - 1, 0);
           const col = Math.max(Number.parseInt(match[2], 10) - 1, 0);
           const excerptParts = [match[3]];
@@ -208,7 +228,7 @@ export default {
           }
 
           messages.push({
-            severity: this.level,
+            severity: lintsev,
             excerpt: excerptParts.join(' '),
             location: {
               file: filePath,

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "level": {
       "type": "string",
       "title": "Perlcritic Level of warning",
-      "default": "info",
+      "description": "If set to auto this applies a mapping between the linter log levels and perlcritic severity. It's more colorful but may be set to constant values too.",
+      "default": "auto",
       "enum": [
+        "auto",
         "info",
         "warning",
         "error"


### PR DESCRIPTION
Introduces a new option to set the severity. This
defaults to 'auto', what applies the mapping
between the linter and perlcritic. Constant
severity is kept as options.

Closes #66